### PR TITLE
Use HTTP headers and params, show status

### DIFF
--- a/tag_build.py
+++ b/tag_build.py
@@ -71,13 +71,13 @@ class TagMergeBot:
             self.current_prs[repo['remote_name']] = []
             res = requests.get(GITHUB_API+'/{owner}/{repo}/issues?labels={labels}&per_page=100'.format(labels=LABEL_TO_FETCH, owner=repo['owner'], repo=repo['name']))
             if res.status_code != 200:
-                logger.error("Could not retrive pull requests from github")
+                logger.error("Could not retrive pull requests from github. Status: {status}".format(status=res.status_code))
                 return False
             issues = res.json()
             for issue in issues:
                 pr_response = requests.get(issue['pull_request']['url'])
                 if res.status_code != 200:
-                    logger.warn("Couldn't fetch the PRs details for PR {pr}".format(pr=issue['']))
+                    logger.warn("Couldn't fetch the PRs details for PR {pr}. Status: {status}".format(pr=issue[''], status=res.status_code))
                     continue
                 pr = pr_response.json()
                 self.current_prs[repo['remote_name']].append({"number": pr['number'], "commit": pr['head']['sha'], "ref": pr['head']['ref']})

--- a/tag_build.py
+++ b/tag_build.py
@@ -33,6 +33,14 @@ MAIN_REPO = PULL_REPOS[1]
 PUSH_REPO = 'git@github.com:citra-emu/citra-bleeding-edge'
 # PUSH_REPO = 'git@github.com:jroweboy/lemon'
 
+GITHUB_API_HEADERS = {
+    'User-Agent': 'citra-emu/lemonbot'
+}
+GITHUB_API_PARAMS = {
+    'client_id': 'xxxx',
+    'client_secret': 'yyyy'
+}
+
 class TagMergeBot:
     ''' Fetches all the pull requests on a repository and merges all the pull requests with a specified tag on them. '''
     def __init__(self, main_repo, pull_repos, push_repo):
@@ -69,13 +77,13 @@ class TagMergeBot:
         self.current_prs = {}
         for repo in self.repos:
             self.current_prs[repo['remote_name']] = []
-            res = requests.get(GITHUB_API+'/{owner}/{repo}/issues?labels={labels}&per_page=100'.format(labels=LABEL_TO_FETCH, owner=repo['owner'], repo=repo['name']))
+            res = requests.get(GITHUB_API+'/{owner}/{repo}/issues?labels={labels}&per_page=100'.format(labels=LABEL_TO_FETCH, owner=repo['owner'], repo=repo['name']), params=GITHUB_API_PARAMS, headers=GITHUB_API_HEADERS)
             if res.status_code != 200:
                 logger.error("Could not retrive pull requests from github. Status: {status}".format(status=res.status_code))
                 return False
             issues = res.json()
             for issue in issues:
-                pr_response = requests.get(issue['pull_request']['url'])
+                pr_response = requests.get(issue['pull_request']['url'], params=GITHUB_API_PARAMS, headers=GITHUB_API_HEADERS)
                 if res.status_code != 200:
                     logger.warn("Couldn't fetch the PRs details for PR {pr}. Status: {status}".format(pr=issue[''], status=res.status_code))
                     continue


### PR DESCRIPTION
I ran into 403 errors due to [GitHub API rate limiting](https://developer.github.com/v3/#rate-limiting).
My solution was to add my client id / secret to raise the limit.

Also the [GitHub API docs state that users should send their information as user-agent](https://developer.github.com/v3/#user-agent-required).

---

This PR adds `GITHUB_API_HEADERS` and `GITHUB_API_PARAMS` to configure and send the required information (auth + user agent).
Additionally this PR adds the http status code to the log so users can debug problems more easily.

---

These variables must currently be added to each API request. Ideally we'd fix this later somehow.
(Also we should probably also pack the other params in a dict too, but that's also for a follow-up).

**This PR depends on #3 or vice-versa. Documentation for the new variables should be added**

*Note that this PR only stubs the config. You must obviously insert a valid `client_id` and `client_secret` to benefit from this change..*