### PR TITLE
Don't auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Pull requests to fix issues with the bot are more than welcome.
 
 ## What does it do?
 
-After doing the self-update, the bot will visit each of the listed `PULL_REPOS`.
+After doing the self-update, the bot will clone the latest `MAIN_REPO` and resync `PUSH_REPO`/master.
+After that, each of the `PULL_REPOS` is visited.
 It will look for PRs on GitHub labelled with `LABEL_TO_FETCH` and merge those onto the `MAIN_REPO`/master branch.
 If a PR fails to merge it will be ignored.
 Once everything has been merged the bot will push the resulting files to the `PUSH_REPO`/`self.branch_name` branch.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pull requests to fix issues with the bot are more than welcome.
 
 ## What does it do?
 
-After doing the self-update, the bot will clone the latest `MAIN_REPO` and resync `PUSH_REPO`/master.
+The bot will clone the latest `MAIN_REPO` and resync `PUSH_REPO`/master.
 After that, each of the `PULL_REPOS` is visited.
 It will look for PRs on GitHub labelled with `LABEL_TO_FETCH` and merge those onto the `MAIN_REPO`/master branch.
 If a PR fails to merge it will be ignored.
@@ -25,10 +25,8 @@ The default configuration is to log to *debug.log*, *error.log* and stdout.
 
 ## Installation
 
-Clone this repo and configure lemonbot by modifying the configuration in *tag_build.py*.
+Download *tag_build.py* and configure lemonbot by modifying the configuration at the top of the file.
 You can then run the script.
-Note that the script depends on being part of a git repo.
-The script uses `git pull origin master` to update itself.
 
 ## License
 

--- a/tag_build.py
+++ b/tag_build.py
@@ -154,6 +154,9 @@ class TagMergeBot:
 
         return total_failed
 
+    def sync(self):
+        _git("push", "-f", self.push_repo["name"], "master", cwd=self.tracking_path)
+
     def push(self):
         _git("push", "-f", self.push_repo["name"], self.branch_name, cwd=self.tracking_path)
 
@@ -212,6 +215,7 @@ if __name__ == "__main__":
     # TODO: Rework this whole workflow to be sane.
     # m = MergeBot(PULL_REPOS, PUSH_REPO)
     t.reclone()
+    t.sync()
     t.pull_branches()
     failed = t.merge()
     logger.info("Number of failed merges: {failed}".format(failed=failed))

--- a/tag_build.py
+++ b/tag_build.py
@@ -185,18 +185,7 @@ def handleRemoveReadonly(func, path, exc):
 
 if __name__ == "__main__":
     logger.info("=== Starting build at {date} ===".format(date=datetime.datetime.now()))
-    logger.debug("Pulling the latest from master")
     base_dir = os.path.abspath(os.path.dirname(__file__))
-    logger.debug("Checking for merge bot updates")
-    _git("fetch", "origin", cwd=base_dir)
-    _, stdout = _git("rev-list", "HEAD...origin/master", "--count", cwd=base_dir)
-    if stdout and int(stdout) > 0:
-        logger.info("=> Changes detected. Pulling latest version and restarting the application")
-        _git("pull", "origin", "master", cwd=base_dir)
-        os.execv(sys.executable, [sys.executable] + sys.argv)
-        sys.exit(0)
-    else:
-        logger.debug("=> No changes to the script repo were detected. Continuing.")
 
     t = TagMergeBot(MAIN_REPO, PULL_REPOS, PUSH_REPO)
     ret = t.fetch_latest_prs()


### PR DESCRIPTION
**Note that this depends on #11 (due to README conflicts). It is also currently untested**

This disables the auto updates as requested in #8 . Users of lemonbot should update their runners / cronjobs to update on their own through git, wget or other means.